### PR TITLE
Powershell 7 support

### DIFF
--- a/doc-downloader.functions.ps1
+++ b/doc-downloader.functions.ps1
@@ -11,8 +11,14 @@ function CreateLogFile
 }
 
 function WriteToLog
-{param([string]$TextToWrite, [string]$file)  
-    $TextToWrite | Out-File $file -Append
+{param([string]$TextToWrite, [string]$file)
+    $powershellVersion = (Get-Host).Version.Major
+    if($powershellVersion -eq 7){
+        $TextToWrite | Out-File -FilePath $file -Append
+    }
+    else {
+        $TextToWrite | Out-File $file -Append
+    }
 }
 
 function CheckDirectory
@@ -25,8 +31,14 @@ function CheckDirectory
 function  MakeHttpGetCall
 {param([string]$URI, [hashtable]$HEADERS, [string]$LOG_FILE)
     $ProgressPreference = 'SilentlyContinue'
-    $response = Invoke-WebRequest -Uri $URI -Headers $HEADERS -MaximumRedirection 0 -ErrorAction SilentlyContinue -ErrorVariable $ProcessError
-    #$ProgressPreference = 'Continue'   
+    $powershellVersion = (Get-Host).Version.Major
+    if($powershellVersion -eq 7){
+        $response = Invoke-WebRequest -Uri $URI -Headers $HEADERS -MaximumRedirection 0 -ErrorAction SilentlyContinue -ErrorVariable $ProcessError -SkipHttpErrorCheck
+    }
+    else {
+        $response = Invoke-WebRequest -Uri $URI -Headers $HEADERS -MaximumRedirection 0 -ErrorAction SilentlyContinue -ErrorVariable $ProcessError
+    }
+    #$ProgressPreference = 'Continue'
     if($ProcessError){
         WriteToLog $ProcessError $LOG_FILE
     }

--- a/doc-downloader.functions.ps1
+++ b/doc-downloader.functions.ps1
@@ -13,7 +13,7 @@ function CreateLogFile
 function WriteToLog
 {param([string]$TextToWrite, [string]$file)
     $powershellVersion = (Get-Host).Version.Major
-    if($powershellVersion -eq 7){
+    if($powershellVersion -ge 7){
         $TextToWrite | Out-File -FilePath $file -Append
     }
     else {
@@ -32,7 +32,7 @@ function  MakeHttpGetCall
 {param([string]$URI, [hashtable]$HEADERS, [string]$LOG_FILE)
     $ProgressPreference = 'SilentlyContinue'
     $powershellVersion = (Get-Host).Version.Major
-    if($powershellVersion -eq 7){
+    if($powershellVersion -ge 7){
         $response = Invoke-WebRequest -Uri $URI -Headers $HEADERS -MaximumRedirection 0 -ErrorAction SilentlyContinue -ErrorVariable $ProcessError -SkipHttpErrorCheck
     }
     else {

--- a/doc-downloader.ps1
+++ b/doc-downloader.ps1
@@ -29,11 +29,13 @@ If($DATED_FOLDERS) {
 Else {
     $FILE_DIR = $DESTINATION_PATH}
 
-$DRIVE_AXLE_HEADERS = @{ Authorization = ("driveaxle=" + $API_KEY) 
-                         Accept = 'application/json'}
+$DRIVE_AXLE_HEADERS = @{ Authorization = ("driveaxle=" + $API_KEY)
+                         Accept = 'application/json'
+                         ContentType = 'application/json'}
 
-$ELEOS_HEADERS = @{ Authorization = ("key=" + $API_KEY)
-                    Accept = 'application/json'}
+$ELEOS_HEADERS = @{ Authorization = ("Key key=" + $API_KEY)
+                    Accept = 'application/json'
+                    ContentType = 'application/json'}
 
 $HEADERS = If ($DRIVE_AXLE) { $DRIVE_AXLE_HEADERS } Else { $ELEOS_HEADERS }
 


### PR DESCRIPTION
So far from my testing, these are the changes needed to support powershell 7. These changes are backwards compatible with powershell 5. 

Reason for changes:

Powershell 7 introduced an issue where if a 302 status was returned it would treat that as an error and throw an exception if a certain flag was not enabled.

Powershel 7 also changed how Out-File is called

These changes check if the host using powershell 7 and modified the calls as such.

Also fixed platform API key header