### PR TITLE
Handle 403's while downloading docs

### DIFF
--- a/doc-downloader.functions.ps1
+++ b/doc-downloader.functions.ps1
@@ -66,12 +66,13 @@ function  MakeHttpDeleteCall
 }
 
 function DownloadFile
-{param([string]$URI, [string]$OutFilePath, [string]$LOG_FILE)
+{param([string]$URI, [string]$FileName, [string]$OutFilePath, [string]$LOG_FILE)
   try {
-    $response = Invoke-WebRequest -Uri $URI -OutFile $OutFilePath
+    $response = Invoke-WebRequest -Uri $URI -OutFile $OutFilePath/$FileName
+    WriteToLog ("File " + $FileName + "  downloaded successfully to " + $OutFilePath) $LOG_FILE
   } catch {
-    if($_.Exception.Response.StatusCode.Value__ -eq 403) {
-      WriteToLog("Document has already been purged, marking the document as delted and moving on to the next one...")
+    if($_.Exception.Response.StatusCode.Value__.ToString() -like '4**') {
+      WriteToLog("Error while downloading document, status code: " + $_.Exception.Response.StatusCode.Value__.ToString() + ". The document may have already been purged, moving onto next document...") $LOG_FILE
     }
     else {
       throw $_

--- a/doc-downloader.ps1
+++ b/doc-downloader.ps1
@@ -80,8 +80,7 @@ do{
             try{
                 $filename = GetFilename $downloadURI $file_count $log_file
                 WriteToLog ("Downloading file " + $filename + " ...." + "`r`n") $log_file
-                DownloadFile $downloadURI $FILE_DIR/$filename $log_file
-                WriteToLog ("File " + $filename + "  downloaded successfully to " + $FILE_DIR) $log_file
+                DownloadFile $downloadURI $filename $FILE_DIR $log_file
             }
             catch{
                 WriteToLog ($_.Exception.Message + "`r`n" + "Error Occured at: " + (Get-Date -format "MM-dd-yyyy HH:mm:s").ToString() + "`r`n") $log_file

--- a/doc-downloader.ps1
+++ b/doc-downloader.ps1
@@ -76,17 +76,18 @@ do{
             $downloadURI = $queuedDoc.download_url
             WriteToLog ("Downloading Document from " + $downloadURI) $log_file
             $file_count++
+
             try{
                 $filename = GetFilename $downloadURI $file_count $log_file
                 WriteToLog ("Downloading file " + $filename + " ...." + "`r`n") $log_file
-                Invoke-WebRequest $downloadURI -OutFile $FILE_DIR/$filename
+                DownloadFile $downloadURI $FILE_DIR/$filename $log_file
                 WriteToLog ("File " + $filename + "  downloaded successfully to " + $FILE_DIR) $log_file
             }
             catch{
                 WriteToLog ($_.Exception.Message + "`r`n" + "Error Occured at: " + (Get-Date -format "MM-dd-yyyy HH:mm:s").ToString() + "`r`n") $log_file
                 break
             }
-            
+
             WriteToLog ("Attempting to delete document " + $redirect + " from the Queue`r`n") $log_file
             $removeDoc = RemoveDocFromQueue $redirect $HEADERS $log_file
             If ($removeDoc){


### PR DESCRIPTION
Issue: If a document does not exist/has already been purged, the doc api will still think the document is there regardless and return a URL to download it, and this URL will return a 403 if you try to download the file from it, since it doesn't exist. The script will stop running once it hits a 403 response

Solution: what these changes will do is if the response from downloading returns a 403, it will ignore this error and continue with the script

I have briefly testing with powershell 5 and 7