### PR TITLE
fix for filepath string concatenation

### DIFF
--- a/doc-downloader.functions.ps1
+++ b/doc-downloader.functions.ps1
@@ -6,7 +6,7 @@ function CreateLogFile
 {param([string]$Dir)
     $CurrentTime = Get-Date -Format yyyy-MM-dd
     $filename = ("Eleos-" + ($CurrentTime + ".log"))
-    $filepath = ($DIR + $filename)
+    $filepath = ($DIR + "\" + $filename)
     return $filepath
 }
 

--- a/doc-downloader.functions.ps1
+++ b/doc-downloader.functions.ps1
@@ -6,7 +6,7 @@ function CreateLogFile
 {param([string]$Dir)
     $CurrentTime = Get-Date -Format yyyy-MM-dd
     $filename = ("Eleos-" + ($CurrentTime + ".log"))
-    $filepath = ($DIR + "\" + $filename)
+    $filepath = Join-Path -Path $Dir -ChildPath $filename
     return $filepath
 }
 


### PR DESCRIPTION
Adding "\" to filepath string definition in CreateLogFile so that the path is built correctly.
Current before:
DIR="C:\Scripts\Logs"
Result would be: "C:\Scripts\LogsEleos2022-12-19.log"

New Behavior:
Resulting Path: "C:\Scripts\Logs\Eleos2022-12-19.log"