### PR TITLE
Enable Tls1.2 and json conversion should use AsHashtable

### DIFF
--- a/doc-downloader.ps1
+++ b/doc-downloader.ps1
@@ -1,5 +1,6 @@
 $Config = Get-Content "configurations.json" | ConvertFrom-Json
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 ###  Configuration variables found in configurations.json
 $API_KEY = $Config.api_key
@@ -72,7 +73,7 @@ do{
             $redirect = $BASE_URL + $response.Headers["Location"]
             WriteToLog ("Redirecting to URL " + $redirect) $log_file
             $queuedDoc = GetDocFromQueue $redirect $HEADERS $log_file
-            $queuedDoc = $queuedDoc | ConvertFrom-Json
+            $queuedDoc = $queuedDoc | ConvertFrom-Json -AsHashtable
             $downloadURI = $queuedDoc.download_url
             WriteToLog ("Downloading Document from " + $downloadURI) $log_file
             $file_count++


### PR DESCRIPTION
PowerShell doesn't always enable newer versions of TLS like TLS 1.2. Most WIndows Servers need it explicitly enabled, otherwise they attempt to only use TLS 1.1 which has been deprecated for awhile.

Some JSON responses from Eleos may have multiple mixed-case keys that cannot be converted into case-insensitive Dictionary, which is the default ConvertFrom-Json setting. Using -AsHasthtable gets around this.